### PR TITLE
Set/change default password using env variable

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/init-openboxcopy/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-openboxcopy/run
@@ -6,3 +6,10 @@ if [[ ! -f /config/.config/openbox/menu.xml ]]; then
     cp /defaults/menu.xml /config/.config/openbox/menu.xml && \
     chown -R abc:abc /config/.config
 fi
+
+if [[ -n "$PASSWORD" ]]; then
+    echo "abc:${PASSWORD}" | chpasswd
+    echo "**** Password set from environment variable 'PASSWORD'. ****"
+else
+    echo "**** No 'PASSWORD' var. The default password 'abc' has been set. ****"
+fi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [ ] I have read the [contributing](https://github.com/linuxserver/docker-firefox/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
<!--- Describe your changes in detail -->
Add support for setting the password of user "abc" using an environment variable called "PASSWORD". This aligns with the method available in LSIO's Calibre.

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
This implements closed Issue #2

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
It has not been tested. Please verify by sight.

## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
Code inspiration taken from LSIO's Calibre:
https://github.com/linuxserver/docker-calibre/blob/master/root/etc/s6-overlay/s6-rc.d/init-calibre-config/run