### PR TITLE
update readme for keymap info

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -45,6 +45,9 @@ app_setup_block: |
   By default the user/pass is abc/abc, if you change your password or want to login manually to the GUI session for any reason use the following link:
   
   * http://yourhost:3000/?login=true
+  
+  If you need to set the on-screen keyboard to a different layout, please use the environment variable `KEYBOARD=<keymap>` A list of keymaps is available below
+  * https://github.com/linuxserver/gclient#keyboard-layouts
 
 # changelog
 changelogs:


### PR DESCRIPTION
closes https://github.com/linuxserver/docker-firefox/issues/13
related to https://github.com/linuxserver/docker-webtop/issues/19

mentions keymap support for customizing the on-screen keyboard, potentially we should add this to the rest as well.. 