### PR TITLE
Language support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,8 @@ RUN \
     && awk '/^P:firefox$/,/V:/' /tmp/APKINDEX | sed -n 2p | sed 's/^V://'); \
   fi && \
   apk add --no-cache \
-    firefox==${FIREFOX_VERSION} && \
+    firefox==${FIREFOX_VERSION} \
+    font-noto-cjk && \
   sed -i 's|</applications>|  <application title="Mozilla Firefox" type="normal">\n    <maximized>yes</maximized>\n  </application>\n</applications>|' /etc/xdg/openbox/rc.xml && \
   echo "**** default firefox settings ****" && \
   FIREFOX_SETTING="/usr/lib/firefox/browser/defaults/preferences/firefox.js" && \
@@ -27,6 +28,19 @@ RUN \
   echo 'pref("datareporting.healthreport.uploadEnabled", false);' >> ${FIREFOX_SETTING} && \
   echo 'pref("trailhead.firstrun.branches", "nofirstrun-empty");' >> ${FIREFOX_SETTING} && \
   echo 'pref("browser.aboutwelcome.enabled", false);' >> ${FIREFOX_SETTING} && \
+  echo "**** add langpacks ****" && \
+  FIREFOX_VERSION=$(curl -sI https://download.mozilla.org/?product=firefox-latest | awk -F '(releases/|/win32)' '/Location/ {print $2}') && \
+  RELEASE_URL="https://releases.mozilla.org/pub/firefox/releases/${FIREFOX_VERSION}/win64/xpi/" && \
+  LANGS=$(curl -Ls ${RELEASE_URL} | awk -F '(xpi">|</a>)' '/href.*xpi/ {print $2}' | tr '\n' ' ') && \
+  EXTENSION_DIR=/usr/lib/firefox/distribution/extensions/ && \
+  mkdir -p ${EXTENSION_DIR} && \
+  for LANG in ${LANGS}; do \
+    LANGCODE=$(echo ${LANG} | sed 's/\.xpi//g'); \
+    echo "Downloading ${LANG} Language pack"; \
+    curl -o \
+      ${EXTENSION_DIR}langpack-${LANGCODE}@firefox.mozilla.org.xpi -Ls \
+      ${RELEASE_URL}${LANG} ; \
+  done && \
   echo "**** cleanup ****" && \
   rm -rf \
     /tmp/*

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -17,7 +17,8 @@ RUN \
     && awk '/^P:firefox$/,/V:/' /tmp/APKINDEX | sed -n 2p | sed 's/^V://'); \
   fi && \
   apk add --no-cache \
-    firefox==${FIREFOX_VERSION} && \
+    firefox==${FIREFOX_VERSION} \
+    font-noto-cjk && \
   sed -i 's|</applications>|  <application title="Mozilla Firefox" type="normal">\n    <maximized>yes</maximized>\n  </application>\n</applications>|' /etc/xdg/openbox/rc.xml && \
   echo "**** default firefox settings ****" && \
   FIREFOX_SETTING="/usr/lib/firefox/browser/defaults/preferences/firefox.js" && \
@@ -27,6 +28,19 @@ RUN \
   echo 'pref("datareporting.healthreport.uploadEnabled", false);' >> ${FIREFOX_SETTING} && \
   echo 'pref("trailhead.firstrun.branches", "nofirstrun-empty");' >> ${FIREFOX_SETTING} && \
   echo 'pref("browser.aboutwelcome.enabled", false);' >> ${FIREFOX_SETTING} && \
+  echo "**** add langpacks ****" && \
+  FIREFOX_VERSION=$(curl -sI https://download.mozilla.org/?product=firefox-latest | awk -F '(releases/|/win32)' '/Location/ {print $2}') && \
+  RELEASE_URL="https://releases.mozilla.org/pub/firefox/releases/${FIREFOX_VERSION}/win64/xpi/" && \
+  LANGS=$(curl -Ls ${RELEASE_URL} | awk -F '(xpi">|</a>)' '/href.*xpi/ {print $2}' | tr '\n' ' ') && \
+  EXTENSION_DIR=/usr/lib/firefox/distribution/extensions/ && \
+  mkdir -p ${EXTENSION_DIR} && \
+  for LANG in ${LANGS}; do \
+    LANGCODE=$(echo ${LANG} | sed 's/\.xpi//g'); \
+    echo "Downloading ${LANG} Language pack"; \
+    curl -o \
+      ${EXTENSION_DIR}langpack-${LANGCODE}@firefox.mozilla.org.xpi -Ls \
+      ${RELEASE_URL}${LANG} ; \
+  done && \
   echo "**** cleanup ****" && \
   rm -rf \
     /tmp/*

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ services:
       - PUID=1000
       - PGID=1000
       - TZ=Etc/UTC
+      - LC_ALL=en_US.UTF-8 #optional
     volumes:
       - /path/to/config:/config
     ports:
@@ -132,6 +133,7 @@ docker run -d \
   -e PUID=1000 \
   -e PGID=1000 \
   -e TZ=Etc/UTC \
+  -e LC_ALL=en_US.UTF-8 `#optional` \
   -p 3000:3000 \
   -p 3001:3001 \
   -v /path/to/config:/config \
@@ -152,6 +154,7 @@ Container images are configured using parameters passed at runtime (such as thos
 | `-e PUID=1000` | for UserID - see below for explanation |
 | `-e PGID=1000` | for GroupID - see below for explanation |
 | `-e TZ=Etc/UTC` | specify a timezone to use, see this [list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List). |
+| `-e LC_ALL=en_US.UTF-8` | Specify the language for the firefox interface. [Complete List](https://github.com/linuxserver/docker-mods/tree/universal-internationalization#other-languages) |
 | `-v /config` | Users home directory in the container, stores local files and settings |
 | `--shm-size=` | This is needed for any modern website to function like youtube. |
 | `--security-opt seccomp=unconfined` | For Docker Engine only, many modern gui apps need this to function on older hosts as syscalls are unknown to Docker. |

--- a/README.md
+++ b/README.md
@@ -268,6 +268,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **08.09.23:** - Add default language support.
 * **13.05.23:** - Rebase to Alpine 3.18.
 * **18.03.23:** - Rebase to KasmVNC base image.
 * **21.10.22:** - Rebase to Alpine 3.16, migrate to s6v3.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -78,6 +78,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "08.09.23:", desc: "Add default language support." }
   - { date: "13.05.23:", desc: "Rebase to Alpine 3.18." }
   - { date: "18.03.23:", desc: "Rebase to KasmVNC base image." }
   - { date: "21.10.22:", desc: "Rebase to Alpine 3.16, migrate to s6v3." }

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -22,6 +22,9 @@ param_container_name: "{{ project_name }}"
 param_usage_include_env: true
 param_env_vars:
   - { env_var: "TZ", env_value: "Europe/London", desc: "Specify a timezone to use EG Europe/London." }
+opt_param_usage_include_env: true
+opt_param_env_vars:
+  - { env_var: "LC_ALL", env_value: "en_US.UTF-8", desc: "Specify the language for the firefox interface. [Complete List](https://github.com/linuxserver/docker-mods/tree/universal-internationalization#other-languages)" }
 param_usage_include_vols: true
 param_volumes:
   - { vol_path: "/config", vol_host_path: "/path/to/config", desc: "Users home directory in the container, stores local files and settings" }


### PR DESCRIPTION
This one is up for debate, it adds 100 megs to the image because of the cjk font install and langpack download. 

Firefox is unique as it does not use system level languages, you have to go out and manually ingest their system extensions to get a translated UI. 

With these changes the user can simply pass the LC_ALL env var and the container will be in their language. 