### PR TITLE
add FIREFOX_CLI env var to sync up with other browser images

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ services:
       - PUID=1000
       - PGID=1000
       - TZ=Etc/UTC
+      - FIREFOX_CLI=https://www.linuxserver.io/ #optional
     volumes:
       - /path/to/config:/config
     ports:
@@ -147,6 +148,7 @@ docker run -d \
   -e PUID=1000 \
   -e PGID=1000 \
   -e TZ=Etc/UTC \
+  -e FIREFOX_CLI=https://www.linuxserver.io/ `#optional` \
   -p 3000:3000 \
   -p 3001:3001 \
   -v /path/to/config:/config \
@@ -166,6 +168,7 @@ Containers are configured using parameters passed at runtime (such as those abov
 | `-e PUID=1000` | for UserID - see below for explanation |
 | `-e PGID=1000` | for GroupID - see below for explanation |
 | `-e TZ=Etc/UTC` | specify a timezone to use, see this [list](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List). |
+| `-e FIREFOX_CLI=https://www.linuxserver.io/` | Specify one or multiple Firefox CLI flags, this string will be passed to the application in full. |
 | `-v /config` | Users home directory in the container, stores local files and settings |
 | `--shm-size=` | This is needed for any modern website to function like youtube. |
 | `--security-opt seccomp=unconfined` | For Docker Engine only, many modern gui apps need this to function on older hosts as syscalls are unknown to Docker. |
@@ -331,6 +334,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **13.02.24:** - Add ability to pass CLI args to Firefox.
 * **10.02.24:** - Update Readme with new env vars and ingest proper PWA icon.
 * **01.01.24:** - Rebase to Alpine 3.19.
 * **13.05.23:** - Rebase to Alpine 3.18.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -31,6 +31,10 @@ param_ports:
   - { external_port: "3001", internal_port: "3001", port_desc: "Firefox desktop gui HTTPS." }
 custom_params:
   - { name: "shm-size", name_compose: "shm_size", value: "1gb",desc: "This is needed for any modern website to function like youtube." }
+# optional variables
+opt_param_usage_include_env: true
+opt_param_env_vars:
+  - { env_var: "FIREFOX_CLI", env_value: "https://www.linuxserver.io/", desc: "Specify one or multiple Firefox CLI flags, this string will be passed to the application in full."}
 opt_security_opt_param: true
 opt_security_opt_param_vars:
   - { run_var: "seccomp=unconfined", compose_var: "seccomp:unconfined", desc: "For Docker Engine only, many modern gui apps need this to function on older hosts as syscalls are unknown to Docker." }
@@ -92,6 +96,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "13.02.24:", desc: "Add ability to pass CLI args to Firefox." }
   - { date: "10.02.24:", desc: "Update Readme with new env vars and ingest proper PWA icon." }
   - { date: "01.01.24:", desc: "Rebase to Alpine 3.19." }
   - { date: "13.05.23:", desc: "Rebase to Alpine 3.18." }

--- a/root/defaults/autostart
+++ b/root/defaults/autostart
@@ -1,1 +1,1 @@
-firefox
+firefox ${FIREFOX_CLI}


### PR DESCRIPTION
This syncs us up with Opera and Chomium to be able to pass CLI variables to firefox. 